### PR TITLE
Add sourceror.exs

### DIFF
--- a/sourceror.exs
+++ b/sourceror.exs
@@ -1,5 +1,6 @@
 # Example of Code Mod
-# Changes
+#
+# Changes:
 #
 #     |> (fn ... end().()
 #

--- a/sourceror.exs
+++ b/sourceror.exs
@@ -1,0 +1,25 @@
+# Example of Code Mod
+# changes `|> (fn -> end().()` into `|> then(fn -end)
+
+Mix.install([
+  {:sourceror, "~> 0.9"}
+])
+
+source = """
+foo
+|> (fn i -> i * 2 end).()
+"""
+
+IO.puts(["Before: \n", source, "\nAfter: "])
+
+source
+|> Sourceror.parse_string!()
+|> Sourceror.postwalk(fn
+  {:|>, meta, [prev, {{:., _, [{:fn, _, _} | _] = contents}, _, _}]}, state ->
+    {{:|>, meta, [prev, {:then, [], contents}]}, state}
+
+  rest, state ->
+    {rest, state}
+end)
+|> Sourceror.to_string()
+|> IO.puts()

--- a/sourceror.exs
+++ b/sourceror.exs
@@ -1,12 +1,18 @@
 # Example of Code Mod
-# changes `|> (fn -> end().()` into `|> then(fn -end)
+# Changes
+#
+#     |> (fn ... end().()
+#
+# into:
+#
+#     |> then(fn ... end)
 
 Mix.install([
   {:sourceror, "~> 0.9"}
 ])
 
 source = """
-foo
+42
 |> (fn i -> i * 2 end).()
 """
 


### PR DESCRIPTION
Example usage of Sourceror to do a code modification.
Wraps anonymous function calls inside pipe with then/1

Output:

>  Before: 
> foo
> |> (fn i -> i * 2 end).()
> 
> After: 
> foo
> |> then(fn i -> i * 2 end)
