### PR TITLE
Add an example of Phoenix LiveView with a single file

### DIFF
--- a/phoenix_live_view.exs
+++ b/phoenix_live_view.exs
@@ -1,0 +1,84 @@
+Application.put_env(:phoenix, :json_library, Jason)
+
+Application.put_env(:sample, SamplePhoenix.Endpoint,
+  http: [ip: {127, 0, 0, 1}, port: 5001],
+  server: true,
+  live_view: [signing_salt: "aaaaaaaa"],
+  secret_key_base: String.duplicate("a", 64)
+)
+
+Mix.install([
+  {:plug_cowboy, "~> 2.5"},
+  {:jason, "~> 1.0"},
+  {:phoenix, "~> 1.6.10"},
+  {:phoenix_live_view, "~> 0.17.10"}
+])
+
+defmodule SamplePhoenix.ErrorView do
+  use Phoenix.View, root: ""
+
+  def render(_, _), do: "error"
+end
+
+defmodule SamplePhoenix.SampleLive do
+  use Phoenix.LiveView, layout: {__MODULE__, "live.html"}
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :count, 0)}
+  end
+
+  def render("live.html", assigns) do
+    ~H"""
+    <script src="https://cdn.jsdelivr.net/npm/phoenix@1.6.10/priv/static/phoenix.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/phoenix_live_view@0.17.10/priv/static/phoenix_live_view.min.js"></script>
+    <script>
+      let liveSocket = new window.LiveView.LiveSocket("/live", window.Phoenix.Socket)
+      liveSocket.connect()
+    </script>
+    <style>
+      * { font-size: 1.1em; }
+    </style>
+    <%= @inner_content %>
+    """
+  end
+
+  def render(assigns) do
+    ~H"""
+    <%= @count %>
+    <button phx-click="inc">+</button>
+    <button phx-click="dec">-</button>
+    """
+  end
+
+  def handle_event("inc", _params, socket) do
+    {:noreply, assign(socket, :count, socket.assigns.count + 1)}
+  end
+
+  def handle_event("dec", _params, socket) do
+    {:noreply, assign(socket, :count, socket.assigns.count - 1)}
+  end
+end
+
+defmodule Router do
+  use Phoenix.Router
+  import Phoenix.LiveView.Router
+
+  pipeline :browser do
+    plug(:accepts, ["html"])
+  end
+
+  scope "/", SamplePhoenix do
+    pipe_through(:browser)
+
+    live("/", SampleLive, :index)
+  end
+end
+
+defmodule SamplePhoenix.Endpoint do
+  use Phoenix.Endpoint, otp_app: :sample
+  socket("/live", Phoenix.LiveView.Socket)
+  plug(Router)
+end
+
+{:ok, _} = Supervisor.start_link([SamplePhoenix.Endpoint], strategy: :one_for_one)
+Process.sleep(:infinity)


### PR DESCRIPTION
The JavaScript is served from a CDN for convenience, so the versions of
Phoenix and LiveView have been locked to match this.

THe ErrorView is implemented in this example to prevent the ErrorView
missing errors being logged.

The way the layout is implemented is probably not best practice! It
makes it simple to code up an example if there are any JS changes
though and minimises the number of modules required.