### PR TITLE
Add Config.Reader standalone example

### DIFF
--- a/config_reader.exs
+++ b/config_reader.exs
@@ -1,0 +1,15 @@
+try do
+  # fake an existing config file (to keep things in a single file here),
+  # which would otherwise exist somewhere outside of git
+  File.write!("config.exs", """
+  import Config
+  config :my_app, :my_config_key, "some-secret-value"
+  """)
+
+  config = Config.Reader.read!("config.exs")
+
+  value = "some-secret-value" = config[:my_app][:my_config_key]
+  IO.puts("Yay, secret config is #{value |> inspect}")
+after
+  File.rm!("config.exs")
+end


### PR DESCRIPTION
I am not sure how typical it is, but as I use `Mix.install` more, I am starting to add credentials for some routine scripts (invoicing etc), without creating a Mix project, so I figured out how to read the manually and created this sample.

A better example could also show how to use this with `Mix.install/2` `:config` option (https://hexdocs.pm/mix/1.13.4/Mix.html#install/2), but I feel it's easier to grasp without this.

Here I create the config file from the script itself, but normally the config will be in a separate, non-versioned file.

Feel free to reject the PR of course, I'll let you judge how relevant this is or not, but I find it quite useful to me at least!