### PR TITLE
Add ExAws.S3 example with Mix.install config

### DIFF
--- a/ex_aws_s3.exs
+++ b/ex_aws_s3.exs
@@ -1,0 +1,22 @@
+# This example illustrates configuring a package directly from Mix.install/2
+
+Mix.install(
+  [
+    {:ex_aws, "~> 2.3"},
+    {:ex_aws_s3, "~> 2.3"},
+    {:hackney, "~> 1.9"},
+    {:jason, "~> 1.3"},
+    {:sweet_xml, "~> 0.6"}
+  ],
+  config: [
+    ex_aws: [
+      access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}],
+      secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}]
+    ]
+  ]
+)
+
+ExAws.S3.list_objects("my-bucket")
+|> ExAws.stream!()
+|> Enum.to_list()
+|> IO.inspect()

--- a/ex_aws_s3.exs
+++ b/ex_aws_s3.exs
@@ -1,5 +1,3 @@
-# This example illustrates configuring a package directly from Mix.install/2
-
 Mix.install(
   [
     {:ex_aws, "~> 2.3"},


### PR DESCRIPTION
Really I wanted to highlight the `:config` and `:system_env` ability from `Mix.install/2`. My actual use case was from a livebook where I needed to use [ConfigParser](https://hexdocs.pm/configparser_ex/) because of SSO.