### PR TITLE
feat: upgrade to phoenix 1.7

### DIFF
--- a/phoenix.exs
+++ b/phoenix.exs
@@ -11,7 +11,7 @@ Application.put_env(:sample, SamplePhoenix.Endpoint,
 Mix.install([
   {:plug_cowboy, "~> 2.5"},
   {:jason, "~> 1.0"},
-  {:phoenix, "~> 1.6"}
+  {:phoenix, "~> 1.7.0-rc.2"}
 ])
 
 defmodule SamplePhoenix.SampleController do

--- a/phoenix_live_view.exs
+++ b/phoenix_live_view.exs
@@ -10,18 +10,16 @@ Application.put_env(:sample, SamplePhoenix.Endpoint,
 Mix.install([
   {:plug_cowboy, "~> 2.5"},
   {:jason, "~> 1.0"},
-  {:phoenix, "~> 1.6.10"},
-  {:phoenix_live_view, "~> 0.17.10"}
+  {:phoenix, "~> 1.7.0-rc.2", override: true},
+  {:phoenix_live_view, "~> 0.18.2"}
 ])
 
 defmodule SamplePhoenix.ErrorView do
-  use Phoenix.View, root: ""
-
   def render(_, _), do: "error"
 end
 
 defmodule SamplePhoenix.SampleLive do
-  use Phoenix.LiveView, layout: {__MODULE__, "live.html"}
+  use Phoenix.LiveView, layout: {__MODULE__, :live}
 
   def mount(_params, _session, socket) do
     {:ok, assign(socket, :count, 0)}
@@ -29,8 +27,8 @@ defmodule SamplePhoenix.SampleLive do
 
   def render("live.html", assigns) do
     ~H"""
-    <script src="https://cdn.jsdelivr.net/npm/phoenix@1.6.10/priv/static/phoenix.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/phoenix_live_view@0.17.10/priv/static/phoenix_live_view.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/phoenix@1.7.0-rc.2/priv/static/phoenix.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/phoenix_live_view@0.18.2/priv/static/phoenix_live_view.min.js"></script>
     <script>
       let liveSocket = new window.LiveView.LiveSocket("/live", window.Phoenix.Socket)
       liveSocket.connect()


### PR DESCRIPTION
Phoenix 1.7 changes how views work, it is no longer required in the ErrorView and layouts now use an atom instead of a string.

Probably best to wait for a final 1.7 release before merging this.