### PR TITLE
Update bandit.exs

### DIFF
--- a/nimble_publisher.ex
+++ b/nimble_publisher.ex
@@ -77,7 +77,7 @@ defmodule Example.Plug do
   end
 end
 
-bandit = {Bandit, plug: Example.Plug, scheme: :http, options: [port: 4000]}
+bandit = {Bandit, plug: Example.Plug, scheme: :http, thousand_island_options: [port: 4000]}
 {:ok, _} = Supervisor.start_link([bandit], strategy: :one_for_one)
 
 # unless running from IEx, sleep idenfinitely so we can serve requests

--- a/nimble_publisher.ex
+++ b/nimble_publisher.ex
@@ -77,7 +77,7 @@ defmodule Example.Plug do
   end
 end
 
-bandit = {Bandit, plug: Example.Plug, scheme: :http, thousand_island_options: [port: 4000]}
+bandit = {Bandit, plug: Example.Plug, scheme: :http, port: 4000}
 {:ok, _} = Supervisor.start_link([bandit], strategy: :one_for_one)
 
 # unless running from IEx, sleep idenfinitely so we can serve requests


### PR DESCRIPTION
In [`0.7.6`](https://github.com/mtrudel/bandit/blob/main/CHANGELOG.md#076-9-apr-2023) Bandit renamed the top-level `options` field to `thousand_island_options`.