### PR TITLE
Add dagger

### DIFF
--- a/dagger.exs
+++ b/dagger.exs
@@ -1,0 +1,25 @@
+Mix.install([:dagger])
+
+# It's requires to have `docker` on the local machine first.
+Dagger.with_connection(
+  fn dag ->
+    source =
+      dag
+      |> Dagger.Client.git("https://github.com/elixir-lang/elixir")
+      |> Dagger.GitRepository.branch("main")
+      |> Dagger.GitRef.tree()
+
+    {:ok, version} = dag
+    |> Dagger.Client.container()
+    |> Dagger.Container.from("hexpm/erlang:27.0.1-alpine-3.20.2")
+    |> Dagger.Container.with_exec(~w"apk add make")
+    |> Dagger.Container.with_workdir("/elixir")
+    |> Dagger.Container.with_mounted_directory("/elixir", source)
+    |> Dagger.Container.with_exec(~w"make")
+    |> Dagger.Container.with_exec(~w"./bin/elixir --version")
+    |> Dagger.Container.stdout()
+
+    IO.puts(version)
+  end,
+  connect_timeout: :timer.minutes(1)
+)

--- a/dagger.exs
+++ b/dagger.exs
@@ -9,15 +9,16 @@ Dagger.with_connection(
       |> Dagger.GitRepository.branch("main")
       |> Dagger.GitRef.tree()
 
-    {:ok, version} = dag
-    |> Dagger.Client.container()
-    |> Dagger.Container.from("hexpm/erlang:27.0.1-alpine-3.20.2")
-    |> Dagger.Container.with_exec(~w"apk add make")
-    |> Dagger.Container.with_workdir("/elixir")
-    |> Dagger.Container.with_mounted_directory("/elixir", source)
-    |> Dagger.Container.with_exec(~w"make")
-    |> Dagger.Container.with_exec(~w"./bin/elixir --version")
-    |> Dagger.Container.stdout()
+    {:ok, version} =
+      dag
+      |> Dagger.Client.container()
+      |> Dagger.Container.from("hexpm/erlang:27.0.1-alpine-3.20.2")
+      |> Dagger.Container.with_exec(~w"apk add make")
+      |> Dagger.Container.with_workdir("/elixir")
+      |> Dagger.Container.with_mounted_directory("/elixir", source)
+      |> Dagger.Container.with_exec(~w"make")
+      |> Dagger.Container.with_exec(~w"./bin/elixir --version")
+      |> Dagger.Container.stdout()
 
     IO.puts(version)
   end,


### PR DESCRIPTION
I add a [dagger](https://dagger.io/) to this example here. The script requires the Docker to be installed on the machine. The script does a simple thing, clone the Elixir compiler, build it, and print the version.