### PR TITLE
Add SQLite3  to ecto_sql.exs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 checksum-Elixir.RustlerPrecompilationExample.Native.exs
 _build
+mix_install_examples*

--- a/ecto_sql.exs
+++ b/ecto_sql.exs
@@ -1,12 +1,14 @@
 Mix.install([
   {:ecto_sql, "~> 3.10"},
   {:postgrex, ">= 0.0.0"}
+  # {:ecto_sqlite3, "~> 0.17"}
 ])
 
 Application.put_env(:foo, Repo, database: "mix_install_examples")
 
 defmodule Repo do
   use Ecto.Repo, adapter: Ecto.Adapters.Postgres, otp_app: :foo
+  # use Ecto.Repo, adapter: Ecto.Adapters.SQLite3, otp_app: :foo
 end
 
 defmodule Migration0 do


### PR DESCRIPTION
`ecto_sql.exs` depends on a running Postgres server, which is a huge requirement coming from a single file script. It would be nice to have an SQLite option in place to quickly switch to it if postgres isn't available.